### PR TITLE
[Release] v3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# v3.1.2 (February 29, 2024)
+ * [#45](https://github.com/sourcetoad/react-native-fs2/pull/48) - Fix ArrayBuffer return on Android.
+
 # v3.1.1 (February 26, 2024)
  * [#44](https://github.com/sourcetoad/react-native-fs2/pull/44) - Add ArrayBuffer support.
  * [#45](https://github.com/sourcetoad/react-native-fs2/pull/45) - ip upgrade to v1.1.9 (example).


### PR DESCRIPTION
# v3.1.2 (February 29, 2024)
 * [#45](https://github.com/sourcetoad/react-native-fs2/pull/48) - Fix ArrayBuffer return on Android.