### PR TITLE
[Release] 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# v3.2.0 (May 17, 2024)
+ * [#51](https://github.com/sourcetoad/react-native-fs2/pull/51) - Add Privacy Manifest support.
+
 # v3.1.3 (February 29, 2024)
  * Properly tag v3.1.2 (re-tag as 3.1.3)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-fs2",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-fs2",
-      "version": "3.1.3",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "base-64": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fs2",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "description": "Native filesystem access for react-native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
# v3.2.0 (May 17, 2024)
 * [#51](https://github.com/sourcetoad/react-native-fs2/pull/51) - Add Privacy Manifest support.