### PR TITLE
[Release] v3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v3.2.1 (July 16, 2024)
+ * [#52](https://github.com/sourcetoad/react-native-fs2/pull/54) - Support RN74
+ * Automatic updates via Dependabot
+
 # v3.2.0 (May 17, 2024)
  * [#51](https://github.com/sourcetoad/react-native-fs2/pull/51) - Add Privacy Manifest support.
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1167,7 +1167,7 @@ PODS:
     - React-logger (= 0.74.2)
     - React-perflogger (= 0.74.2)
     - React-utils (= 0.74.2)
-  - RNFS2 (3.2.0):
+  - RNFS2 (3.2.1):
     - React-Core
   - SocketRocket (0.7.0)
   - Yoga (0.0.0)
@@ -1406,7 +1406,7 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 56b642bf605ba5afa500d35790928fc1d51565ad
   React-utils: 4476b7fcbbd95cfd002f3e778616155241d86e31
   ReactCommon: ecad995f26e0d1e24061f60f4e5d74782f003f12
-  RNFS2: 2240895a249f8fa093b88d36623fef1f96ffe11b
+  RNFS2: 24fd7b91b365bb113d45cd10b869e791ad9b7a2e
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 11ac5a6bca36f590409f9cee1ac14383ed8460c9
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-fs2",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-fs2",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "base-64": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fs2",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Native filesystem access for react-native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
# v3.2.1 (July 16, 2024)
 * [#52](https://github.com/sourcetoad/react-native-fs2/pull/54) - Support RN74
 * Automatic updates via Dependabot