### PR TITLE
perf: leverage `try-with-resources` statement when handling input streams

### DIFF
--- a/android/src/main/java/com/rnfs2/RNFSManager.java
+++ b/android/src/main/java/com/rnfs2/RNFSManager.java
@@ -215,8 +215,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void readFile(String filepath, Promise promise) {
-    try {
-      InputStream inputStream = getInputStream(filepath);
+    try (InputStream inputStream = getInputStream(filepath)) {
       byte[] inputData = getInputStreamBytes(inputStream);
       String base64Content = Base64.encodeToString(inputData, Base64.NO_WRAP);
 
@@ -229,8 +228,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void read(String filepath, int length, int position, Promise promise) {
-    try {
-      InputStream inputStream = getInputStream(filepath);
+    try (InputStream inputStream = getInputStream(filepath)) {
       byte[] buffer = new byte[length];
       inputStream.skip(position);
       int bytesRead = inputStream.read(buffer, 0, length);


### PR DESCRIPTION
Context:
- calling these methods produces `LeakedClosableViolation` on android `StrictMode`
- fix ensures any opened input stream are properly handled and closed