### PR TITLE
MediaStore updates and fixes

### DIFF
--- a/android/src/main/java/com/rnfs2/RNFSMediaStoreManager.java
+++ b/android/src/main/java/com/rnfs2/RNFSMediaStoreManager.java
@@ -10,6 +10,7 @@ import android.os.Build;
 import android.os.Environment;
 import android.os.ParcelFileDescriptor;
 import android.provider.MediaStore;
+import android.os.FileUtils;
 import android.util.Log;
 
 import androidx.annotation.RequiresApi;
@@ -380,11 +381,7 @@ public class RNFSMediaStoreManager extends ReactContextBaseJavaModule {
             byte[] transformedBytes = RNFSFileTransformer.sharedFileTransformer.onWriteFile(bytes);
             out.write(transformedBytes);
           } else {
-            byte[] buf = new byte[1024 * 10];
-            int read;
-            while ((read = fin.read(buf)) > 0) {
-              out.write(buf, 0, read);
-            }
+            FileUtils.copy(fin, out);
           }
         }
 

--- a/android/src/main/java/com/rnfs2/RNFSMediaStoreManager.java
+++ b/android/src/main/java/com/rnfs2/RNFSMediaStoreManager.java
@@ -1,5 +1,6 @@
 package com.rnfs2;
 
+import android.app.RecoverableSecurityException;
 import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.content.Context;


### PR DESCRIPTION
## Summary

This pull request significantly enhances the reliability and robustness of MediaStore file operations in `RNFSMediaStoreManager.java`, particularly for Android Q (API 29) and above. Key improvements include the adoption of the `IS_PENDING` flag for safer file copying, introduction of a dedicated cleanup mechanism for MediaStore entries upon failure, and more granular error handling, including `RecoverableSecurityException`.

## Detailed Changes

*   **Revamped `copyToMediaStore` Method:**
    *   Implements a two-stage save process for Android Q+ using the `IS_PENDING` flag:
        1.  The media file entry is created and marked as pending (`IS_PENDING = 1`).
        2.  Data is written to the file.
        3.  The file is then committed by marking `IS_PENDING = 0`.
    *   Introduces `cleanupMediaStoreEntry(fileUri, resolver)`: If any step (initial creation, marking pending, writing data, or committing) fails, this new helper is called to remove the MediaStore entry, preventing orphaned files.
    *   Adds explicit checks for source file existence before proceeding.
    *   Provides more specific error messages and promise rejections throughout the process.

*   **Enhanced `writeToMediaFile` (Private Overload):**
    *   Introduced a new boolean parameter `shouldCleanupOnFailure`.
    *   If `shouldCleanupOnFailure` is `true` (as it is when called from the revamped `copyToMediaStore`), the `cleanupMediaStoreEntry` method is invoked if an exception occurs during the write operation.
    *   Improved resource management by using try-with-resources for `ParcelFileDescriptor`, `FileInputStream`, and `FileOutputStream`, ensuring these are closed properly.
    *   Added more robust pre-condition checks (e.g., `fileUri == null`, source file existence, `ParcelFileDescriptor` validity).
    *   Refined error reporting for write failures.

*   **Updated `writeToMediaFile` (Public Method):**
    *   The public-facing `writeToMediaFile` (called from JavaScript) now calls the private overload with `shouldCleanupOnFailure` set to `false` by default. This maintains its original behavior where it doesn't automatically clean up an existing MediaStore entry if only the write operation fails (as the entry might have been created independently).

*   **New `cleanupMediaStoreEntry` Helper Method:**
    *   A private utility method to safely delete a MediaStore entry using its URI and a `ContentResolver`.
    *   Includes logging for any errors encountered during the deletion attempt itself.

*   **Improved `updateExistingMediaFile` Method:**
    *   Adds specific handling for `SecurityException` during `resolver.update()`.
    *   If a `RecoverableSecurityException` is caught (for Android Q+), it rejects the promise with `"ERR_RECOVERABLE_SECURITY"`, indicating that the user might be able to grant permission.
    *   Other `SecurityException` instances are rejected with `"ERR_SECURITY_EXCEPTION"`.

## Motivation and Context

The previous implementation of `copyToMediaStore` and associated file writing could leave incomplete or orphaned entries in the MediaStore if an error occurred mid-process (e.g., after creating the entry but before or during data writing). This was particularly problematic for Android Q and later versions, which emphasize scoped storage and the `IS_PENDING` pattern for safer file transactions.

These changes aim to:
1.  **Improve Atomicity and Safety:** Ensure that file copy operations are more atomic and safer by correctly using the `IS_PENDING` flag. The file is only made fully available once data is successfully written and committed.
2.  **Prevent Orphaned Entries:** Actively clean up MediaStore entries if critical parts of the `copyToMediaStore` flow fail.
3.  **Enhance Error Handling:** Provide more specific error codes and messages (e.g., `RecoverableSecurityException`) to the JavaScript side, allowing for better user feedback or recovery flows.
4.  **Improve Resource Management:** Utilize try-with-resources in file writing operations to prevent resource leaks.