### PR TITLE
[Release] v3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+# v3.4.1 (March 9, 2025)
+ * [#109](https://github.com/sourcetoad/react-native-fs2/pull/109) - Fix OIDC publish
+
+# v3.4.0 (March 9, 2025)
  * [#82](https://github.com/sourcetoad/react-native-fs2/pull/92) - Upgrade to RN82.
  * [#103](https://github.com/sourcetoad/react-native-fs2/pull/103) - Adds Trusted Publishing
  * [#105](https://github.com/sourcetoad/react-native-fs2/pull/105) - Improve handling for Android Content URIs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-fs2",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-fs2",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "MIT",
       "dependencies": {
         "base-64": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fs2",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Native filesystem access for react-native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
# v3.4.1 (March 9, 2025)
 * [#109](https://github.com/sourcetoad/react-native-fs2/pull/109) - Fix OIDC publish
